### PR TITLE
ci: Simplify CI by running in Python Docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,9 @@ jobs:
           python -m pip install -r ${{ matrix.kind }}/requirements.txt
 
       - name: Generate list of models
-        run: python ${{ matrix.kind }}/main.py > ${{ matrix.kind }}.json
+        run: |
+          . venv/bin/activate
+          python ${{ matrix.kind }}/main.py > ${{ matrix.kind }}.json
 
       - name: Check valid JSON
         run: jq -reM '""' ${{ matrix.kind }}.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   list_models:
     runs-on: ubuntu-latest
+    container: python:3.10-bullseye
     strategy:
       matrix:
         kind:
@@ -32,45 +33,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-
-      - name: Remove Chrome
+      - name: Install Chromium
         run: |
-          sudo apt purge google-chrome-stable chromium chromium-browser chromium-chromedriver
-
-      - name: Install Chromium 105
-        run: |
-          which chromium
-          ls -lavh /usr/bin/chromium
-          #sudo apt install google-chrome-stable==105.0.5195.102-1
-          sudo snap install chromium
-          which chromium
-          ls -lavh /usr/bin/chromium
+          apt-get update
+          apt-get install --no-install-recommends -y \
+            chromium=105.0.5195.52-1~deb11u1 \
+            jq
           chromium --version
-
-      - name: Install ChromeDriver 105
-        run: |
-          which chromedriver
-          find /usr/bin -name "chromedriver"
-          ls -lavh /usr/bin/chromedriver
-          sudo rm /usr/bin/chromedriver
-          curl https://chromedriver.storage.googleapis.com/105.0.5195.19/chromedriver_linux64.zip -o chromedriver.zip
-          sudo unzip chromedriver.zip -d /usr/bin/
-          ls -lavh /usr/bin/chromedriver
-          chromedriver -v
 
       - name: Install dependencies
         run: |
+          python -m venv venv
+          . venv/bin/activate
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install -r ${{ matrix.kind }}/requirements.txt
-
-      - name: Check Versions
-        run: |
-          chromium --version
-          chromedriver -v
 
       - name: Generate list of models
         run: python ${{ matrix.kind }}/main.py > ${{ matrix.kind }}.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
             jq
           chromium --version
 
-      - name: Install dependencies
+      - name: Install Python dependencies
         run: |
           python -m venv venv
           . venv/bin/activate


### PR DESCRIPTION
Simplify the CI and make debugging a more reasonable process by running the `list_models` jobs in a Python Docker container and installing a pinned version of `chromium`.

```
* Run list_models job in python:3.10-bullseye Docker container to simplify setup.
* Install chromium=105.0.5195.52-1~deb11u1 for reproducible runs.
```