### PR TITLE
fix: Drop specification of exact build of chromium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           apt-get update
           apt-get install --no-install-recommends -y \
-            chromium=105.0.5195.52-1~deb11u1 \
+            chromium \
             jq
           chromium --version
 


### PR DESCRIPTION
Even in a Docker container the exact build is too transient and fragile to pin to. As a result just install 'chromium' and don't attempt to install a specific version.

```
* Even in a Docker container the exact build is too transient and fragile
  to pin to. As a result just install 'chromium' and don't attempt to install
  a specific version.
```