### PR TITLE
chore: Removed unused pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,14 +63,14 @@ repos:
       # E501: line too long
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.981
+    rev: v0.971
     hooks:
       - id: mypy
         files: src
         args: []
 
 -   repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.5.2
+    rev: 1.4.0
     hooks:
     - id: nbqa-pyupgrade
       additional_dependencies: [pyupgrade==2.38.2]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,6 @@ repos:
       args: ["--pytest-test-first"]
     - id: requirements-txt-fixer
     - id: trailing-whitespace
-      # exclude generated files
-      exclude: ^validation/|\.dtd$|\.xml$
 
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.38.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,14 +63,14 @@ repos:
       # E501: line too long
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v0.981
     hooks:
       - id: mypy
         files: src
         args: []
 
 -   repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.4.0
+    rev: 1.5.2
     hooks:
     - id: nbqa-pyupgrade
       additional_dependencies: [pyupgrade==2.38.2]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,12 +38,6 @@ repos:
     hooks:
     - id: black-jupyter
 
--   repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
-    hooks:
-    - id: blacken-docs
-      additional_dependencies: [black==22.6.0]
-
 -   repo: https://github.com/asottile/yesqa
     rev: v1.4.0
     hooks:
@@ -57,19 +51,6 @@ repos:
       # E203: whitespace before ':'
       # E402: module level import not at top of file
       # E501: line too long
-
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
-    hooks:
-      - id: mypy
-        files: src
-        args: []
-
--   repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.4.0
-    hooks:
-    - id: nbqa-pyupgrade
-      additional_dependencies: [pyupgrade==2.38.2]
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.2.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,6 @@ repos:
     - id: check-xml
     - id: debug-statements
     - id: end-of-file-fixer
-      # exclude generated files
-      exclude: ^validation/|\.dtd$|\.json$|\.xml$
     - id: mixed-line-ending
     - id: name-tests-test
       args: ["--pytest-test-first"]


### PR DESCRIPTION
```
* Remove unused pre-commit hooks: blacken-docs, mirrors-mypy, nbQA.
* Remove unneeded pre-commit hook 'exclude' options.
```