### PR TITLE
feat: Update webdriver-manager version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,9 @@ jobs:
         run: |
           apt-get update
           apt-get install --no-install-recommends -y \
-            jq \
-            chromium
-          wget https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/linux64/chromedriver-linux64.zip -O temp.zip
-          unzip temp.zip
-          rm temp.zip
-          echo "PATH=$(PWD)/chromedriver-linux64:${PATH}" >> "$GITHUB_ENV"
+            chromium \
+            jq
+          chromium --version
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,10 @@ jobs:
           - atlas
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
+      - name: Set up Python
         uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
           apt-get install --no-install-recommends -y \
             jq \
             chromium
-          wget https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/linux64/chrome-linux64.zip -O temp.zip
+          wget https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/linux64/chromedriver-linux64.zip -O temp.zip
           unzip temp.zip
           rm temp.zip
-          echo "PATH=$(PWD)/chrome-linux64:${PATH}" >> "$GITHUB_ENV"
+          echo "PATH=$(PWD)/chromedriver-linux64:${PATH}" >> "$GITHUB_ENV"
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,12 @@ jobs:
         run: |
           apt-get update
           apt-get install --no-install-recommends -y \
-            chromium \
-            jq
-          chromium --version
+            jq \
+            chromium
+          wget https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96/linux64/chrome-linux64.zip -O temp.zip
+          unzip temp.zip
+          rm temp.zip
+          echo "PATH=$(PWD)/chrome-linux64:${PATH}" >> "$GITHUB_ENV"
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,21 +25,14 @@ on:
 jobs:
   list_models:
     runs-on: ubuntu-latest
-    container: python:3.10-bullseye
     strategy:
       matrix:
         kind:
           - atlas
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Chromium
-        run: |
-          apt-get update
-          apt-get install --no-install-recommends -y \
-            chromium \
-            jq
-          chromium --version
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
 
       - name: Install Python dependencies
         run: |

--- a/atlas/main.py
+++ b/atlas/main.py
@@ -1,5 +1,6 @@
 from selenium import webdriver
-#from webdriver_manager.chrome import ChromeDriverManager
+
+# from webdriver_manager.chrome import ChromeDriverManager
 
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.chrome.options import Options
@@ -11,7 +12,7 @@ import json
 
 url = "https://twiki.cern.ch/twiki/bin/view/AtlasPublic"
 
-#service = Service(ChromeDriverManager().install())
+# service = Service(ChromeDriverManager().install())
 
 options = Options()
 options.add_argument("--headless")
@@ -21,7 +22,7 @@ options.add_argument("--disable-dev-shm-usage")
 options.add_argument("disable-infobars")
 options.add_argument("--disable-extensions")
 
-with webdriver.Chrome(options=options) as driver: # , service=service) as driver:
+with webdriver.Chrome(options=options) as driver:  # , service=service) as driver:
     driver.get(url)
 
     # it's asynchronous so we force a wait

--- a/atlas/main.py
+++ b/atlas/main.py
@@ -1,8 +1,4 @@
 from selenium import webdriver
-
-# from webdriver_manager.chrome import ChromeDriverManager
-
-from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
@@ -12,8 +8,6 @@ import json
 
 url = "https://twiki.cern.ch/twiki/bin/view/AtlasPublic"
 
-# service = Service(ChromeDriverManager().install())
-
 options = Options()
 options.add_argument("--headless")
 options.add_argument("--no-sandbox")
@@ -22,7 +16,7 @@ options.add_argument("--disable-dev-shm-usage")
 options.add_argument("disable-infobars")
 options.add_argument("--disable-extensions")
 
-with webdriver.Chrome(options=options) as driver:  # , service=service) as driver:
+with webdriver.Chrome(options=options) as driver:
     driver.get(url)
 
     # it's asynchronous so we force a wait

--- a/atlas/main.py
+++ b/atlas/main.py
@@ -1,5 +1,5 @@
 from selenium import webdriver
-from webdriver_manager.chrome import ChromeDriverManager
+#from webdriver_manager.chrome import ChromeDriverManager
 
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.chrome.options import Options
@@ -11,7 +11,7 @@ import json
 
 url = "https://twiki.cern.ch/twiki/bin/view/AtlasPublic"
 
-service = Service(ChromeDriverManager().install())
+#service = Service(ChromeDriverManager().install())
 
 options = Options()
 options.add_argument("--headless")
@@ -21,7 +21,7 @@ options.add_argument("--disable-dev-shm-usage")
 options.add_argument("disable-infobars")
 options.add_argument("--disable-extensions")
 
-with webdriver.Chrome(options=options, service=service) as driver:
+with webdriver.Chrome(options=options) as driver: # , service=service) as driver:
     driver.get(url)
 
     # it's asynchronous so we force a wait

--- a/atlas/requirements.txt
+++ b/atlas/requirements.txt
@@ -1,3 +1,3 @@
+chromedriver-binary-auto==0.3.1
 selenium==4.4.3
 webdriver-manager==4.0.0
-chromedriver-binary-auto==0.3.1

--- a/atlas/requirements.txt
+++ b/atlas/requirements.txt
@@ -1,3 +1,1 @@
-chromedriver-binary-auto==0.3.1
-selenium==4.4.3
-webdriver-manager==4.0.0
+selenium==4.12.0

--- a/atlas/requirements.txt
+++ b/atlas/requirements.txt
@@ -1,2 +1,2 @@
 selenium==4.4.3
-webdriver-manager==3.8.3
+webdriver-manager==4.0.0

--- a/atlas/requirements.txt
+++ b/atlas/requirements.txt
@@ -1,2 +1,3 @@
 selenium==4.4.3
 webdriver-manager==4.0.0
+chromedriver-binary-auto==0.3.1


### PR DESCRIPTION
Seems selenium isn't supporting webdriver-manager (and that's what's screwing things up for us presumably): https://github.com/SeleniumHQ/selenium/issues/12617#issuecomment-1695575228

Resolves #29 . This drops the docker container which I had hoped was stable enough (turns out it's not) and instead rely on the GitHub Action runners preinstalled stuff. [8480d20](https://github.com/pyhf/public-probability-models/pull/30/commits/8480d2006c7d43466bbab5a68d10cab6628d14b4) contains the variation that works in the container however.

```
* Drop use of python:3.10-bullseye Docker container for GitHub Actions runners environment.
* Remove use of webdriver-manager, as it is not recommended to use with modern
  selenium.
   - c.f. https://github.com/SeleniumHQ/selenium/issues/12617#issuecomment-1695575228
* Update selenium to v4.12.0.
```