### PR TITLE
ci: Group Dependabot updates into monthly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    labels:
+      - "github-actions"
+      - "dependencies"
+    reviewers:
+      - "kratsg"
+      - "matthewfeickert"


### PR DESCRIPTION
* Add Dependabot schedule for grouped updates.